### PR TITLE
use name as ID

### DIFF
--- a/R/02_place.R
+++ b/R/02_place.R
@@ -181,7 +181,7 @@ place_server <- function(
           leaflet.minicharts::addMinicharts(
             boundaries$lon,
             boundaries$lat,
-            layerId = boundaries$pcode,
+            layerId = boundaries[[rv$geo_name_col]],
             chartdata = 1,
             width = 0,
             height = 0
@@ -218,7 +218,7 @@ place_server <- function(
 
           leaflet::leafletProxy("map", session) %>%
             leaflet.minicharts::updateMinicharts(
-              layerId = df_map$pcode,
+              layerId = df_map$name,
               chartdata = chart_data,
               opacity = .7,
               fillColor = epi_pals()$d310[1],
@@ -232,7 +232,7 @@ place_server <- function(
         } else {
           leaflet::leafletProxy("map", session) %>%
             leaflet.minicharts::updateMinicharts(
-              layerId = df_map$pcode,
+              layerId = df_map$name,
               chartdata = 1,
               width = 0,
               height = 0
@@ -298,7 +298,7 @@ place_server <- function(
             leaflet.minicharts::addMinicharts(
               lng = boundaries$lon,
               lat = boundaries$lat,
-              layerId = df_map$pcode,
+              layerId = df_map$name,
               chartdata = chart_data,
               opacity = .8,
               fillColor = epi_pals()$d310[1],


### PR DESCRIPTION
At the moment the leaflet maps are hardcoded to use `pcode` as ID. This PR proposes to change this to the name which is given as an argument to `launch_module` and thus can be changed by the user.